### PR TITLE
Fix DataVisualization rendering issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ Allow to introduce a PIN or verification Code.
 
 ![PinBox](https://raw.githubusercontent.com/jsuarezruiz/TemplateMAUI/main/images/pinbox.png)
 
+### ProgressBar
+
+Provides a customizable visual to indicate the progress of a task.
+
+![ProgressBar](https://raw.githubusercontent.com/jsuarezruiz/TemplateMAUI/main/images/progressbar.png)
+
+#### Rate
+
+Allows users to select a rating value from a group of visual symbols like stars.
+
+![Rate](https://raw.githubusercontent.com/jsuarezruiz/TemplateMAUI/main/images/rate.png)
+
 ## Copyright and license
 
 Code released under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/TemplateMAUI/DataVisualization/AreaChart.cs
+++ b/src/TemplateMAUI/DataVisualization/AreaChart.cs
@@ -101,6 +101,7 @@ namespace TemplateMAUI.DataVisualization
 
         void AddAreaChartToLayout()
         {
+            _chartPanel.Children.Clear();
             _chartPanel.Children.Add(_areaChart);
         }
 

--- a/src/TemplateMAUI/DataVisualization/BarChart.cs
+++ b/src/TemplateMAUI/DataVisualization/BarChart.cs
@@ -119,6 +119,7 @@ namespace TemplateMAUI.DataVisualization
 
         void AddBarChartToLayout()
         {
+            _chartPanel.Children.Clear();
             _chartPanel.Children.Add(_barChart);
         }
 

--- a/src/TemplateMAUI/DataVisualization/Base/CategoryAxis.cs
+++ b/src/TemplateMAUI/DataVisualization/Base/CategoryAxis.cs
@@ -150,9 +150,9 @@ namespace TemplateMAUI.DataVisualization
             for (int i = 0; i < _valueLabels.Count; i++)
             {
                 AbsoluteLayout.SetLayoutBounds(_valueLabels[i],
-                    new Rect(_locations[i] - _valueLabels[i].Width / 2, _valueLabels[i].Y - _valueTicks[i].Height, _valueLabels[i].Width, _valueLabels[i].Height));
+                    new Rect(_locations[i] - _valueLabels[i].Width / 2, _valueLabels[i].Y, _valueLabels[i].Width, _valueLabels[i].Height));
                 AbsoluteLayout.SetLayoutBounds(_valueTicks[i],
-                    new Rect(_locations[i], _valueTicks[i].Y - _valueTicks[i].Height, _valueTicks[i].Width, _valueTicks[i].Height));
+                    new Rect(_locations[i], _valueTicks[i].Y, _valueTicks[i].Width, _valueTicks[i].Height));
             }
         }
     }

--- a/src/TemplateMAUI/DataVisualization/Base/GridLines.cs
+++ b/src/TemplateMAUI/DataVisualization/Base/GridLines.cs
@@ -8,12 +8,12 @@ namespace TemplateMAUI.DataVisualization
 
         AbsoluteLayout _gridLayout;
         List<double> _locations;
-        readonly List<Line> _gridLines;
+        readonly List<BoxView> _gridLines;
 
         public GridLines()
         {
             _locations = new List<double>();
-            _gridLines = new List<Line>();
+            _gridLines = new List<BoxView>();
 
             VerticalOptions = LayoutOptions.Fill;
             HorizontalOptions = LayoutOptions.Fill;
@@ -32,6 +32,7 @@ namespace TemplateMAUI.DataVisualization
             base.OnApplyTemplate();
 
             _gridLayout = GetTemplateChild(ElementGridLayout) as AbsoluteLayout;
+   
         }
 
         public void UpdateLocations(IEnumerable<double> locations)
@@ -59,28 +60,20 @@ namespace TemplateMAUI.DataVisualization
         {
             for (int i = 0; i < count; i++)
             {
-                UpdateLineX(i);
-                UpdateLineY(i);
+                UpdateLineLocation(i);
             }
         }
 
-        void UpdateLineX(int i)
+        void UpdateLineLocation(int i)
         {
-            if (_gridLayout != null && _gridLines.Count > i)
-            {
-                if (_gridLines[i].X2 != _gridLayout.Width)
-                    _gridLines[i].X2 = _gridLayout.Width;
-            }
-        }
-
-        void UpdateLineY(int i)
-        {      
-            if (_gridLines.Count > i && _gridLines[i].Y1 != _locations[i])
+            if (_gridLines.Count > i && _gridLines[i].TranslationY != _locations[i])
             {
                 var max = _locations.Max();
-                var height = _gridLayout.Height;
-                var y = 2 * (height - (_locations[i] * height / max)) + 1;
-                _gridLines[i].Y1 = _gridLines[i].Y2 = y;
+                var height = _gridLayout.Frame.Height;
+                var y = (height - (_locations[i] * height / max)) + 1;
+
+                _gridLines[i].TranslationY = y;
+                _gridLines[i].WidthRequest = _gridLayout.Width;
             }
         }
 
@@ -88,18 +81,15 @@ namespace TemplateMAUI.DataVisualization
         {
             for (int i = count; i < _locations.Count; i++)
             {
-                Line line = new Line
+                BoxView line = new BoxView
                 {
-                    Aspect = Stretch.Fill,
-                    Opacity = 0.25,
-                    Stroke = new SolidColorBrush(Colors.Gray),
-                    StrokeThickness = 1,
-                    X1 = 0
+                    Background = new SolidColorBrush(Colors.LightGray),
+                    HeightRequest = 1,
+                    WidthRequest = _gridLayout.Width,
                 };
                 _gridLines.Add(line);
 
-                UpdateLineX(i);
-                UpdateLineY(i);
+                UpdateLineLocation(i);
 
                 _gridLayout.Children.Add(_gridLines[i]);
             }

--- a/src/TemplateMAUI/DataVisualization/Base/ValueAxis.cs
+++ b/src/TemplateMAUI/DataVisualization/Base/ValueAxis.cs
@@ -148,8 +148,10 @@ namespace TemplateMAUI.DataVisualization
             {
                 var y = height - (_locations[i] * height / max);
 
-                AbsoluteLayout.SetLayoutBounds(_valueBoxes[i], new Rect(_valueBoxes[i].X + _valueTicks[i].Width, y - _valueBoxes[i].Height / 2, _valueBoxes[i].Width, _valueBoxes[i].Height));
-                AbsoluteLayout.SetLayoutBounds(_valueTicks[i], new Rect(_valueTicks[i].X + _valueTicks[i].Width, y, _valueTicks[i].Width, _valueTicks[i].Height));
+                AbsoluteLayout.SetLayoutBounds(_valueBoxes[i], new Rect(_valueBoxes[i].X, y, _valueBoxes[i].Width, _valueBoxes[i].Height));
+                AbsoluteLayout.SetLayoutBounds(_valueTicks[i], new Rect(_valueTicks[i].X, y, _valueTicks[i].Width, _valueTicks[i].Height));
+
+
             }
         }
     }

--- a/src/TemplateMAUI/DataVisualization/Base/ValueAxis.cs
+++ b/src/TemplateMAUI/DataVisualization/Base/ValueAxis.cs
@@ -150,8 +150,6 @@ namespace TemplateMAUI.DataVisualization
 
                 AbsoluteLayout.SetLayoutBounds(_valueBoxes[i], new Rect(_valueBoxes[i].X, y, _valueBoxes[i].Width, _valueBoxes[i].Height));
                 AbsoluteLayout.SetLayoutBounds(_valueTicks[i], new Rect(_valueTicks[i].X, y, _valueTicks[i].Width, _valueTicks[i].Height));
-
-
             }
         }
     }

--- a/src/TemplateMAUI/DataVisualization/LineChart.cs
+++ b/src/TemplateMAUI/DataVisualization/LineChart.cs
@@ -93,14 +93,15 @@ namespace TemplateMAUI.DataVisualization
             _lineChart = new Polyline
             {
                 Aspect = Stretch.Fill,
-                WidthRequest = 100,
                 Stroke = new SolidColorBrush(Color),
-                StrokeThickness = 2
+                StrokeThickness = 2,
+                Margin = new Thickness(24, 0)
             };
         }
 
         void AddLineChartToLayout()
         {
+            _chartPanel.Children.Clear();
             _chartPanel.Children.Add(_lineChart);
         }
 

--- a/src/TemplateMAUI/Themes/Styles/CategoryAxis.xaml
+++ b/src/TemplateMAUI/Themes/Styles/CategoryAxis.xaml
@@ -37,7 +37,6 @@
                             Grid.Row="2"
                             HorizontalOptions="Fill"
                             VerticalOptions="Fill" />
-
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
Fixes:
- Fix crash on BarChart resizing the Window on Windows.
- Fix GridLines not rendering.
- Fix incorrect LineChart size.
- Fix incorrect axis label position after resizing the control (for example, resizing the Window).

<img width="1231" alt="image" src="https://github.com/user-attachments/assets/2fe7cb39-22ab-411c-9619-d374ad6c09fd" />
