### PR TITLE
Fix GridSplitter wrong indicator rendering

### DIFF
--- a/src/TemplateMAUI.Gallery/ViewModels/MainViewModel.cs
+++ b/src/TemplateMAUI.Gallery/ViewModels/MainViewModel.cs
@@ -62,7 +62,7 @@ namespace TemplateMAUI.Gallery.ViewModels
                 new GalleryItem { Title = "Divider", SubTitle = "Displays a separator between views.", Icon = "divider.png", Color = Colors.Orchid  },
                 new GalleryItem { Title = "ExpanderView", SubTitle = "Provide content in an expandable area and includes a header.", Icon = "expanderview.png", Color = Colors.HotPink  },
                 new GalleryItem { Title = "FeedbackView", SubTitle = "Provide visual feedback to touch interactions.", Icon = "feedbackview.png", Color = Colors.PaleGoldenrod  },
-                new GalleryItem { Title = "GridSplitter", SubTitle = "Represents the control that redistributes space between columns or rows of a Grid control.", Icon = "gridsplitter.png", Color = Colors.DarkOrchid },
+                new GalleryItem { Title = "GridSplitter", SubTitle = "Represents the control that redistributes space between columns or rows of a Grid control.", Icon = "gridsplitter.png", Color = Colors.DarkOrchid, Status = GalleryItemStatus.InProgress },
                 new GalleryItem { Title = "Marquee", SubTitle = "Use this control to add an attention–getting text message that scrolls continuously across the screen.", Icon = "marquee.png", Color = Colors.DarkRed },
                 new GalleryItem { Title = "PinBox", SubTitle = "Allow to introduce a PIN or verification Code.", Icon = "pinbox.png", Color = Colors.PaleVioletRed },
                 new GalleryItem { Title = "PropertyGrid", SubTitle = "Allows end-users to edit properties of the objects associated with it.", Icon = "propertygrid.png", Color = Colors.DarkSlateGrey },

--- a/src/TemplateMAUI/Controls/GridSplitter/ElementToBoolConverter.cs
+++ b/src/TemplateMAUI/Controls/GridSplitter/ElementToBoolConverter.cs
@@ -6,7 +6,7 @@ namespace TemplateMAUI.Controls
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value == null;
+            return value is null;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/TemplateMAUI/Controls/GridSplitter/GridSplitter.cs
+++ b/src/TemplateMAUI/Controls/GridSplitter/GridSplitter.cs
@@ -10,8 +10,10 @@ namespace TemplateMAUI.Controls
     public class GridSplitter : TemplatedView
     {
         const string ElementGridSplitter = "PART_GridSplitter";
+        const string ElementIndicator = "PART_GridSplitterIndicator";
 
         Grid _gridSplitter;
+        Layout _indicator;
 
         double _previousPositionX;
         double _previousPositionY;
@@ -48,7 +50,9 @@ namespace TemplateMAUI.Controls
             base.OnApplyTemplate();
 
             _gridSplitter = GetTemplateChild(ElementGridSplitter) as Grid;
+            _indicator = GetTemplateChild(ElementIndicator) as Layout;
 
+            UpdateIndicator();
             UpdateIsEnabled();
         }
 
@@ -57,7 +61,10 @@ namespace TemplateMAUI.Controls
             base.OnPropertyChanged(propertyName);
 
             if (propertyName == ResizeDirectionProperty.PropertyName)
+            {
+                UpdateIndicator();
                 UpdateLayout();
+            }
             else if (propertyName == IsEnabledProperty.PropertyName)
                 UpdateIsEnabled();
         }
@@ -85,7 +92,7 @@ namespace TemplateMAUI.Controls
             switch (e.StatusType)
             {
                 case GestureStatus.Running:
-                    if (DeviceInfo.Platform == DevicePlatform.iOS)
+                    if (DeviceInfo.Platform == DevicePlatform.iOS || DeviceInfo.Platform == DevicePlatform.WinUI)
                     {
                         var totalX = e.TotalX - _previousPositionX;
                         var totalY = e.TotalY - _previousPositionY;
@@ -105,9 +112,20 @@ namespace TemplateMAUI.Controls
             }
         }
 
+        void UpdateIndicator()
+        {
+            if (_indicator is null)
+                return;
+
+            if (ResizeDirection == GridResizeDirection.Columns)
+                _indicator.Rotation = 90;
+            else
+                _indicator.Rotation = 0;
+        }
+
         void UpdateLayout(double offsetX = 0, double offsetY = 0)
         {
-            if (!(Parent is Grid))
+            if (Parent is not Grid)
                 // TODO: Throw Exception?
                 return;
 
@@ -129,7 +147,7 @@ namespace TemplateMAUI.Controls
 
             if (columnCount <= 1 || column == 0 || column == columnCount - 1)
                 return;
-            
+
             ColumnDefinition previousColumn = grid.ColumnDefinitions[column - 1];
 
             double previousRowWidth;

--- a/src/TemplateMAUI/Themes/Styles/GridSplitter.xaml
+++ b/src/TemplateMAUI/Themes/Styles/GridSplitter.xaml
@@ -10,42 +10,44 @@
 
     <controls:ElementToBoolConverter x:Key="ElementToBoolConverter" />
 
+    <ControlTemplate x:Key="GridSplitterControlTemplate">
+        <Grid
+           x:Name="PART_GridSplitter">
+            <Grid
+               BackgroundColor="{TemplateBinding BackgroundColor}">
+                <StackLayout
+                    x:Name="PART_GridSplitterIndicator"
+                    WidthRequest="16"
+                    VerticalOptions="Center"
+                    HorizontalOptions="Center"
+                    IsVisible="{TemplateBinding Element, Converter={StaticResource ElementToBoolConverter}}">
+                    <BoxView
+                        Background="{StaticResource GridSplitterIndicatorBrush}"
+                        HeightRequest="2"
+                        Margin="0, 1" />
+                    <BoxView
+                        Background="{StaticResource GridSplitterIndicatorBrush}"
+                        HeightRequest="2"
+                        Margin="0, 1" />
+                    <BoxView
+                        Background="{StaticResource GridSplitterIndicatorBrush}"
+                        HeightRequest="2"
+                        Margin="0, 1" />
+                </StackLayout>
+            </Grid>
+            <ContentPresenter
+                Content="{TemplateBinding Element}"
+                HorizontalOptions="Fill"
+                VerticalOptions="Fill" />
+        </Grid>
+    </ControlTemplate>
+    
     <Style TargetType="controls:GridSplitter">
         <Setter Property="HorizontalOptions" Value="Fill" />
         <Setter Property="VerticalOptions" Value="Fill" />
         <Setter Property="MinimumWidthRequest" Value="16" />
         <Setter Property="MinimumHeightRequest" Value="16" />
-        <Setter Property="ControlTemplate">
-            <Setter.Value>
-                <ControlTemplate>
-                    <Grid
-                        x:Name="PART_GridSplitter">
-                        <Grid
-                            HeightRequest="16"
-                            BackgroundColor="{TemplateBinding BackgroundColor}">
-                                <StackLayout
-                                    Padding="6"
-                                    VerticalOptions="Center"
-                                    HorizontalOptions="Center"
-                                    IsVisible="{TemplateBinding Element, Converter={StaticResource ElementToBoolConverter}}">
-                                    <Line
-                                        X2="10"
-                                        Stroke="{StaticResource GridSplitterIndicatorBrush}"
-                                        StrokeThickness="2" />
-                                    <Line
-                                        X2="10"
-                                        Stroke="{StaticResource GridSplitterIndicatorBrush}"
-                                        StrokeThickness="2" />
-                                </StackLayout>
-                            </Grid>
-                        <ContentPresenter
-                            Content="{TemplateBinding Element}"
-                            HorizontalOptions="Fill"
-                            VerticalOptions="Fill" />
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="ControlTemplate"  Value="{StaticResource GridSplitterControlTemplate}"/>
     </Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
Fix GridSplitter wrong indicator rendering.
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/7645d017-dce6-4e31-b7af-d0a5c8debc15" />
