### PR TITLE
Fixed Controls errors with Dark Themes

### DIFF
--- a/src/TemplateMAUI.Gallery/App.xaml
+++ b/src/TemplateMAUI.Gallery/App.xaml
@@ -8,10 +8,14 @@
     <Application.Resources>
         <ResourceDictionary>
 
-            <!-- COLORS -->
-            <Color x:Key="NavBarBackgroundColor">#4c79f2</Color>
-            <Color x:Key="BackgroundColor">#F8F8F8</Color>
-
+            <!-- LIGHT COLORS -->
+            <Color x:Key="LightNavBarBackgroundColor">#4c79f2</Color>
+            <Color x:Key="LightBackgroundColor">#F8F8F8</Color>
+            
+            <!-- DARK COLORS -->
+            <Color x:Key="DarkNavBarBackgroundColor">#2757d7</Color>
+            <Color x:Key="DarkBackgroundColor">#2e2e2e</Color>
+            
             <!-- CONVERTERS -->
             <converters:ColorToBrushConverter x:Key="ColorToBrushConverter" />
             <converters:GalleryItemStatusToBoolConverter x:Key="GalleryItemStatusToBoolConverter" />

--- a/src/TemplateMAUI.Gallery/Views/AvatarViewGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/AvatarViewGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.AvatarViewGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="AvatarView Gallery">
     <ContentPage

--- a/src/TemplateMAUI.Gallery/Views/BadgeViewGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/BadgeViewGallery.xaml
@@ -5,7 +5,7 @@
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     xmlns:viewmodels="clr-namespace:TemplateMAUI.Gallery.ViewModels"
     x:Class="TemplateMAUI.Gallery.Views.BadgeViewGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="BadgeView Gallery">
     <ContentPage

--- a/src/TemplateMAUI.Gallery/Views/ButtonGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/ButtonGallery.xaml
@@ -7,9 +7,9 @@
     <VerticalStackLayout
         Padding="12">
         <controls:Button
-            Background="LightGray"
+            Background="{AppThemeBinding Light=LightGray, Dark=#3e3e3e}"
             BorderBrush="DarkGray"
-            TextColor="Black"
+            TextColor="{AppThemeBinding Light=Black, Dark=White}"
             Content="Button"
             Margin="0, 6"
             Clicked="OnButtonClicked"/>

--- a/src/TemplateMAUI.Gallery/Views/CarouselViewGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/CarouselViewGallery.xaml
@@ -5,7 +5,7 @@
     xmlns:viewmodels="clr-namespace:TemplateMAUI.Gallery.ViewModels"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.CarouselViewGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="CarouselView Gallery">
    <TabbedPage.Resources>

--- a/src/TemplateMAUI.Gallery/Views/ChatBubbleGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/ChatBubbleGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.ChatBubbleGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="ChatBubble Gallery">
     <ContentPage

--- a/src/TemplateMAUI.Gallery/Views/CircleProgressBarGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/CircleProgressBarGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.CircleProgressBarGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="CircleProgressBar Gallery">
     <ContentPage

--- a/src/TemplateMAUI.Gallery/Views/CustomNavigationPage.xaml
+++ b/src/TemplateMAUI.Gallery/Views/CustomNavigationPage.xaml
@@ -3,6 +3,6 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="TemplateMAUI.Gallery.Views.CustomNavigationPage"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White">
 </NavigationPage>

--- a/src/TemplateMAUI.Gallery/Views/DataVisualizationGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/DataVisualizationGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:datavisualization="clr-namespace:TemplateMAUI.DataVisualization;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.DataVisualizationGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="DataVisualization Gallery">
     <ContentPage

--- a/src/TemplateMAUI.Gallery/Views/GridSplitterGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/GridSplitterGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.GridSplitterGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="GridSplitter Gallery">
     <ContentPage

--- a/src/TemplateMAUI.Gallery/Views/MainView.xaml
+++ b/src/TemplateMAUI.Gallery/Views/MainView.xaml
@@ -5,18 +5,18 @@
     xmlns:viewmodels="clr-namespace:TemplateMAUI.Gallery.ViewModels"
     xmlns:templates="clr-namespace:TemplateMAUI.Gallery.Views.Templates"
     x:Class="TemplateMAUI.Gallery.Views.MainView"
-    BackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     Title="Welcome to TemplateMAUI!">
     <ContentPage.Resources>
         <ResourceDictionary>
 
             <Style x:Key="SubTitleTextStyle" TargetType="Label">
-                <Setter Property="TextColor" Value="White" />
+                <Setter Property="TextColor" Value="{AppThemeBinding Light=Black, Dark=White}" />
                 <Setter Property="FontSize" Value="Micro" />
             </Style>
 
             <Style x:Key="SectionTextStyle" TargetType="Label">
-                <Setter Property="TextColor" Value="Black" />
+                <Setter Property="TextColor" Value="{AppThemeBinding Light=Black, Dark=White}" />
                 <Setter Property="FontSize" Value="Micro" />
                 <Setter Property="Margin" Value="12, 12, 12, 0" />
             </Style>
@@ -49,7 +49,7 @@
     <ContentPage.Content>
         <ScrollView>
             <Grid
-                BackgroundColor="{StaticResource NavBarBackgroundColor}">
+                BackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
@@ -82,7 +82,7 @@
                     </Grid.RowDefinitions>
                     <BoxView
                         Grid.RowSpan="3"
-                        Color="{StaticResource BackgroundColor}"
+                        Color="{AppThemeBinding Dark={StaticResource DarkBackgroundColor}, Light={StaticResource LightBackgroundColor}}"
                         CornerRadius="24, 24, 0, 0"/>
                     <!-- TRENDING -->
                     <StackLayout
@@ -117,7 +117,7 @@
                         Grid.Row="1">
                         <Frame
                             HasShadow="False"
-                            BackgroundColor="{StaticResource NavBarBackgroundColor}"
+                            BackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
                             Padding="0"
                             CornerRadius="12"
                             Margin="12, 0">
@@ -153,7 +153,7 @@
                             Style="{StaticResource SectionTextStyle}"/>
                         <Frame
                             HasShadow="False"
-                            BackgroundColor="White"
+                            BackgroundColor="{AppThemeBinding Light=White, Dark=Black}"
                             Padding="0"
                             Margin="12, 0, 12, 12">
                             <CollectionView 

--- a/src/TemplateMAUI.Gallery/Views/MarqueeGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/MarqueeGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.MarqueeGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="Marquee Gallery">
     <ContentPage

--- a/src/TemplateMAUI.Gallery/Views/PinBoxGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/PinBoxGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.PinBoxGallery"  
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="PinBox Gallery">
     <ContentPage 

--- a/src/TemplateMAUI.Gallery/Views/ProgressBarGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/ProgressBarGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.ProgressBarGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="ProgressBar Gallery">
     <ContentPage

--- a/src/TemplateMAUI.Gallery/Views/ProgressButtonGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/ProgressButtonGallery.xaml
@@ -8,19 +8,19 @@
         Padding="12">
         <controls:ProgressButton
             x:Name="ProgressButton1"
-            Background="LightGray"
+            Background="{AppThemeBinding Light=LightGray, Dark=#3e3e3e}"
             BorderBrush="DarkGray"
-            ProgressColor="Black"
-            TextColor="Black"
+            ProgressColor="{AppThemeBinding Light=Black, Dark=White}"
+            TextColor="{AppThemeBinding Light=Black, Dark=White}"
             Content="Progress"
             Margin="0, 6"
             Clicked="OnProgressButtonClicked" />
         <controls:ProgressButton
             x:Name="ProgressButton2"
-            Background="LightGray"
+            Background="{AppThemeBinding Light=LightGray, Dark=#3e3e3e}"
             BorderBrush="DarkGray"
-            ProgressColor="Black"
-            TextColor="Black"
+            ProgressColor="{AppThemeBinding Light=Black, Dark=White}"
+            TextColor="{AppThemeBinding Light=Black, Dark=White}"
             Margin="0, 6"
             Clicked="OnProgressButtonClicked">
             <controls:ProgressButton.Content>
@@ -35,11 +35,11 @@
                         Grid.Column="1"
                         FontAttributes="Bold"
                         Text="Progress"
-                        TextColor="Gray"/>
+                        TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}"/>
                     <Label
                         Grid.Column="2"
                         Text="Button"
-                        TextColor="Black"/>
+                        TextColor="{AppThemeBinding Light=Black, Dark=White}"/>
                     <Image 
                         Grid.Column="3"
                         HeightRequest="24"

--- a/src/TemplateMAUI.Gallery/Views/RateGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/RateGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.RateGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="Rate Gallery">
     <ContentPage

--- a/src/TemplateMAUI.Gallery/Views/SegmentedControlGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/SegmentedControlGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.SegmentedControlGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="SegmentedControl Gallery">
     <TabbedPage.Resources>

--- a/src/TemplateMAUI.Gallery/Views/ShieldGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/ShieldGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="TemplateMAUI.Gallery.Views.ShieldGallery"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="Shield Gallery">
     <ContentPage

--- a/src/TemplateMAUI.Gallery/Views/SliderGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/SliderGallery.xaml
@@ -82,7 +82,7 @@
                 <Label Text="Center" Grid.Row="1" Grid.ColumnSpan="3" HorizontalOptions="FillAndExpand" HorizontalTextAlignment="Center"/>
             </Grid>
 
-            <Label TextColor="Black" FontAttributes="Bold" Margin="0,10,0,0">
+            <Label TextColor="{AppThemeBinding Light=Black, Dark=White}" FontAttributes="Bold" Margin="0,10,0,0">
                 <Label.FormattedText>
                     <FormattedString>
                         <FormattedString.Spans>

--- a/src/TemplateMAUI.Gallery/Views/StepBarGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/StepBarGallery.xaml
@@ -22,10 +22,10 @@
             RowDefinitions="*, Auto">
             <controls:StepBar
                 StepIndex="{Binding StepIndex}"
-                Color="Black"
+                Color="{AppThemeBinding Light=Black, Dark=White}"
                 ColorSelected="{StaticResource SelectedColor}"
                 TextColor="DarkGray"
-                TextColorSelected="Black">
+                TextColorSelected="{AppThemeBinding Light=Black, Dark=White}">
                 <controls:StepBar.Items>
                     <controls:StepBarItems>
                         <controls:StepBarItem
@@ -44,10 +44,12 @@
                 Grid.Row="1">
                 <Button 
                     Text="Previous"
-                    Command="{Binding PreviousCommand}"/>
+                    Command="{Binding PreviousCommand}"
+                    Margin="0, 6"/>
                 <Button 
                     Text="Next"
-                    Command="{Binding NextCommand}"/>
+                    Command="{Binding NextCommand}"
+                    Margin="0, 6"/>
             </HorizontalStackLayout>
         </Grid>
     </VerticalStackLayout>

--- a/src/TemplateMAUI.Gallery/Views/TagGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/TagGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.TagGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="Tag Gallery">
     <ContentPage

--- a/src/TemplateMAUI.Gallery/Views/Templates/GalleryItemTemplate.xaml
+++ b/src/TemplateMAUI.Gallery/Views/Templates/GalleryItemTemplate.xaml
@@ -7,7 +7,7 @@
         <ResourceDictionary>
 
             <Style x:Key="TitleTextStyle" TargetType="Label">
-                <Setter Property="TextColor" Value="Black" />
+                <Setter Property="TextColor" Value="{AppThemeBinding Light=Black, Dark=White}" />
             </Style>
 
             <Style x:Key="SubTitleTextStyle" TargetType="Label">

--- a/src/TemplateMAUI.Gallery/Views/ToggleSwitchGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/ToggleSwitchGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="TemplateMAUI.Gallery.Views.ToggleSwitchGallery"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}"
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}"
     BarTextColor="White"
     Title="ToggleSwitch Gallery">
     <ContentPage

--- a/src/TemplateMAUI.Gallery/Views/TreeViewGallery.xaml
+++ b/src/TemplateMAUI.Gallery/Views/TreeViewGallery.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls;assembly=TemplateMAUI"
     x:Class="TemplateMAUI.Gallery.Views.TreeViewGallery"
-    BarBackgroundColor="{StaticResource NavBarBackgroundColor}" 
+    BarBackgroundColor="{AppThemeBinding Dark={StaticResource DarkNavBarBackgroundColor}, Light={StaticResource LightNavBarBackgroundColor}}" 
     BarTextColor="White"
     Title="TreeView Gallery">
     <ContentPage

--- a/src/TemplateMAUI/Controls/Divider/Divider.cs
+++ b/src/TemplateMAUI/Controls/Divider/Divider.cs
@@ -29,7 +29,7 @@
         }
 
         public static readonly BindableProperty LineStrokeProperty =
-            BindableProperty.Create(nameof(LineStroke), typeof(Color), typeof(Divider), Colors.Black);
+            BindableProperty.Create(nameof(LineStroke), typeof(Color), typeof(Divider), Application.Current.RequestedTheme == AppTheme.Light ? Colors.Black : Colors.White);
 
         public Color LineStroke
         {

--- a/src/TemplateMAUI/Controls/Rate/Rate.cs
+++ b/src/TemplateMAUI/Controls/Rate/Rate.cs
@@ -76,7 +76,7 @@ namespace TemplateMAUI.Controls
         }
 
         public static readonly BindableProperty UnSelectedStrokeProperty =
-            BindableProperty.Create(nameof(UnSelectedStroke), typeof(Color), typeof(Rate), Colors.Black);
+            BindableProperty.Create(nameof(UnSelectedStroke), typeof(Color), typeof(Rate), Application.Current.RequestedTheme == AppTheme.Light ? Colors.Black : Colors.White);
 
         public Color UnSelectedStroke
         {

--- a/src/TemplateMAUI/Controls/Rate/RateItem.cs
+++ b/src/TemplateMAUI/Controls/Rate/RateItem.cs
@@ -49,7 +49,7 @@ namespace TemplateMAUI.Controls
         }
 
         public static readonly BindableProperty UnSelectedStrokeProperty =
-            BindableProperty.Create(nameof(UnSelectedStroke), typeof(Color), typeof(RateItem), Colors.Black);
+            BindableProperty.Create(nameof(UnSelectedStroke), typeof(Color), typeof(RateItem), Application.Current.RequestedTheme == AppTheme.Light ? Colors.Black : Colors.White);
 
         public Color UnSelectedStroke
         {

--- a/src/TemplateMAUI/Controls/StepBar/ColorToInverseColorConverter.cs
+++ b/src/TemplateMAUI/Controls/StepBar/ColorToInverseColorConverter.cs
@@ -1,0 +1,26 @@
+﻿using System.Globalization;
+namespace TemplateMAUI.Controls
+{
+    public class ColorToInverseColorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return ConvertColorToInverseColor(value);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return null;
+        }
+
+        private Color ConvertColorToInverseColor(object value)
+        {
+            if (value != null && value is Color color)
+            {
+                return new Color(1 - color.Red, 1 - color.Green, 1 - color.Blue);
+            }
+
+            throw new ArgumentException("Expected value to be a type of Color", nameof(value));
+        }
+    }
+}

--- a/src/TemplateMAUI/Controls/TreeView/TreeView.cs
+++ b/src/TemplateMAUI/Controls/TreeView/TreeView.cs
@@ -75,7 +75,7 @@ namespace TemplateMAUI.Controls
         }
 
         public static readonly BindableProperty TextColorProperty =
-            BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(TreeView), Colors.Black);
+            BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(TreeView), Application.Current.RequestedTheme == AppTheme.Light ? Colors.Black : Colors.White);
 
         public Color TextColor
         {

--- a/src/TemplateMAUI/Themes/Styles/StepBar.xaml
+++ b/src/TemplateMAUI/Themes/Styles/StepBar.xaml
@@ -5,6 +5,8 @@
     x:Class="TemplateMAUI.Themes.StepBar"
     xmlns:controls="clr-namespace:TemplateMAUI.Controls">
 
+    <controls:ColorToInverseColorConverter  x:Key="ColorToInverseColorConverter"/>
+    
     <Style TargetType="controls:StepBar">
         <Setter Property="ControlTemplate">
             <Setter.Value>
@@ -42,6 +44,7 @@
                             <Label 
                                 HorizontalOptions="Center"
                                 VerticalOptions="Center"
+                                TextColor="{TemplateBinding CurrentColor, Converter={StaticResource ColorToInverseColorConverter}}"
                                 Text="{TemplateBinding Index}"/>
                         </Border>
                         <Label 


### PR DESCRIPTION
Applied changes to fix issues in controls using dark controls.

Gallery using Light Theme:
![image](https://github.com/user-attachments/assets/258d7661-474d-48cb-a5de-339647d9d9d8)

Gallery using Dark Theme:
![image](https://github.com/user-attachments/assets/5559cea7-6705-4389-b7da-605636f6ad76)

StepBar:
![image](https://github.com/user-attachments/assets/0c56d731-f433-4d5e-bb60-823f62988ebd)

Fix #27 